### PR TITLE
发布1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ sse协议的后端API, 比websocket轻量的实时通信,
         <dependency>
             <groupId>com.github.wangzihaogithub</groupId>
             <artifactId>sse-server</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         
 2.  配置业务逻辑 （后端）

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.wangzihaogithub</groupId>
     <artifactId>sse-server</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <name>sse-server</name>
     <description>Sse server for Spring Boot</description>
     <url>https://github.com/wangzihaogithub/sse-server.git</url>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>com.github.wangzihaogithub</groupId>
             <artifactId>spring-boot-protocol</artifactId>
-            <version>2.3.6</version>
+            <version>2.3.8</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -94,7 +94,7 @@
         <connection>scm:git:https://github.com/wangzihaogithub/sse-server.git</connection>
         <developerConnection>scm:git:git@github.com:wangzihaogithub/sse-server.git</developerConnection>
         <url>git@github.com:wangzihaogithub/sse-server.git</url>
-        <tag>v1.2.0</tag>
+        <tag>v1.2.1</tag>
     </scm>
 
     <!-- 开发者信息 -->

--- a/src/main/java/com/github/sseserver/ConnectionQueryService.java
+++ b/src/main/java/com/github/sseserver/ConnectionQueryService.java
@@ -1,10 +1,16 @@
 package com.github.sseserver;
 
+import com.github.sseserver.remote.ConnectionDTO;
+
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
 public interface ConnectionQueryService {
+
+    /* getConnection */
+
+    <ACCESS_USER> List<ConnectionDTO<ACCESS_USER>> getConnectionDTOAll();
 
     /* getUser */
 

--- a/src/main/java/com/github/sseserver/local/SseEmitter.java
+++ b/src/main/java/com/github/sseserver/local/SseEmitter.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  * @author wangzihaogithub 2022-11-12
  */
 public class SseEmitter<ACCESS_USER> extends org.springframework.web.servlet.mvc.method.annotation.SseEmitter implements MessageRepository.Query {
-    public static final String VERSION = "1.2.0";
+    public static final String VERSION = "1.2.1";
     public static final String EVENT_ADD_LISTENER = "addListener";
     public static final String EVENT_REMOVE_LISTENER = "removeListener";
 
@@ -49,6 +49,7 @@ public class SseEmitter<ACCESS_USER> extends org.springframework.web.servlet.mvc
     private final long createTime = System.currentTimeMillis();
     private final Map<String, Object> httpParameters = new LinkedHashMap<>(6);
     private final Map<String, String> httpHeaders = new LinkedHashMap<>(6);
+    private String serverId;
     private boolean connect = false;
     private boolean complete = false;
     private boolean writeable = false;
@@ -116,6 +117,14 @@ public class SseEmitter<ACCESS_USER> extends org.springframework.web.servlet.mvc
 
     public void addListeningWatch(Consumer<SseChangeEvent<ACCESS_USER, Set<String>>> watch) {
         listenersWatchList.add(watch);
+    }
+
+    public String getServerId() {
+        return serverId;
+    }
+
+    void setServerId(String serverId) {
+        this.serverId = serverId;
     }
 
     public IOException getSendError() {

--- a/src/main/java/com/github/sseserver/qos/AtLeastOnceMessage.java
+++ b/src/main/java/com/github/sseserver/qos/AtLeastOnceMessage.java
@@ -1,9 +1,11 @@
 package com.github.sseserver.qos;
 
+import com.github.sseserver.util.AutoTypeBean;
+
 import java.io.Serializable;
 import java.util.Collection;
 
-public class AtLeastOnceMessage implements Message {
+public class AtLeastOnceMessage extends AutoTypeBean implements Message {
     private String id;
 
     private String eventName;
@@ -21,8 +23,9 @@ public class AtLeastOnceMessage implements Message {
 
     public AtLeastOnceMessage(String eventName, Object body, int filters) {
         this.eventName = eventName;
-        this.body = body;
         this.filters = filters;
+        this.body = body;
+        retainClassName(body);
     }
 
     @Override

--- a/src/main/java/com/github/sseserver/qos/AtLeastOnceSendService.java
+++ b/src/main/java/com/github/sseserver/qos/AtLeastOnceSendService.java
@@ -9,6 +9,8 @@ import com.github.sseserver.remote.ClusterConnectionService;
 import com.github.sseserver.remote.ClusterMessageRepository;
 import com.github.sseserver.remote.RemoteResponseMessage;
 import com.github.sseserver.util.LambdaUtil;
+import com.github.sseserver.util.SpringUtil;
+import com.github.sseserver.util.WebUtil;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -31,6 +33,7 @@ public class AtLeastOnceSendService<ACCESS_USER> implements SendService<QosCompl
     protected final MessageRepository messageRepository;
     protected final Map<String, QosCompletableFuture<Integer>> futureMap = new ConcurrentHashMap<>(32);
     protected final Set<String> sendingSet = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    protected final String serverId = SpringUtil.filterNonAscii(WebUtil.getIPAddress(WebUtil.port));
 
     public AtLeastOnceSendService(LocalConnectionService localConnectionService, MessageRepository messageRepository) {
         this.localConnectionService = localConnectionService;
@@ -50,7 +53,7 @@ public class AtLeastOnceSendService<ACCESS_USER> implements SendService<QosCompl
     }
 
     public QosCompletableFuture<Integer> qosSend(Function<SendService, ?> sendFunction, Supplier<AtLeastOnceMessage> messageSupplier) {
-        QosCompletableFuture<Integer> future = new QosCompletableFuture<>("qos" + Message.newId());
+        QosCompletableFuture<Integer> future = new QosCompletableFuture<>(Message.newId("qos", serverId));
         if (localConnectionService.isEnableCluster()) {
             ClusterConnectionService cluster = localConnectionService.getCluster();
 

--- a/src/main/java/com/github/sseserver/qos/MemoryMessageRepository.java
+++ b/src/main/java/com/github/sseserver/qos/MemoryMessageRepository.java
@@ -16,6 +16,11 @@ public class MemoryMessageRepository implements MessageRepository {
     }
 
     @Override
+    public List<Message> list() {
+        return new ArrayList<>(messageMap.values());
+    }
+
+    @Override
     public List<Message> select(Query query) {
         if (messageMap.isEmpty()) {
             return Collections.emptyList();

--- a/src/main/java/com/github/sseserver/qos/Message.java
+++ b/src/main/java/com/github/sseserver/qos/Message.java
@@ -1,8 +1,9 @@
 package com.github.sseserver.qos;
 
+import com.github.sseserver.util.SnowflakeIdWorker;
+
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.UUID;
 
 public interface Message extends Serializable {
     int FILTER_TENANT_ID = (1 << 1);
@@ -11,8 +12,8 @@ public interface Message extends Serializable {
     int FILTER_LISTENER_NAME = (1 << 4);
     int FILTER_CHANNEL = (1 << 5);
 
-    static String newId() {
-        return UUID.randomUUID().toString().replace("-", "");
+    static String newId(String type, String serverId) {
+        return type + "" + serverId + "-" + SnowflakeIdWorker.INSTANCE.nextId();
     }
 
     String getListenerName();

--- a/src/main/java/com/github/sseserver/qos/MessageRepository.java
+++ b/src/main/java/com/github/sseserver/qos/MessageRepository.java
@@ -15,6 +15,13 @@ public interface MessageRepository extends AutoCloseable {
     String insert(Message message);
 
     /**
+     * 返回全部的消息
+     *
+     * @return 全部的消息
+     */
+    List<Message> list();
+
+    /**
      * 查询满足条件的消息
      *
      * @param query 条件
@@ -48,7 +55,8 @@ public interface MessageRepository extends AutoCloseable {
         Set<String> getListeners();
 
         default boolean existListener(String listener) {
-            return getListeners().contains(listener);
+            Set<String> listeners = getListeners();
+            return listeners != null && listeners.contains(listener);
         }
     }
 }

--- a/src/main/java/com/github/sseserver/qos/QosCompletableFuture.java
+++ b/src/main/java/com/github/sseserver/qos/QosCompletableFuture.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 public class QosCompletableFuture<T> extends CompletableFuture<T> {
     /**
      * 消息ID
-     * {@link Message#newId()}
+     * {@link Message#newId(String, String)}}
      */
     private final String messageId;
 

--- a/src/main/java/com/github/sseserver/remote/ClusterConnectionService.java
+++ b/src/main/java/com/github/sseserver/remote/ClusterConnectionService.java
@@ -3,6 +3,7 @@ package com.github.sseserver.remote;
 import com.github.sseserver.ConnectionQueryService;
 import com.github.sseserver.SendService;
 import com.github.sseserver.local.LocalConnectionService;
+import com.github.sseserver.springboot.SseServerProperties;
 import com.github.sseserver.util.ReferenceCounted;
 
 import java.io.Serializable;
@@ -15,6 +16,14 @@ public interface ClusterConnectionService extends ConnectionQueryService, SendSe
                                                 Supplier<ReferenceCounted<List<RemoteConnectionService>>> remoteSupplier) {
         return new ClusterConnectionServiceImpl(localSupplier, remoteSupplier);
     }
+
+    /* getUsers */
+
+    <ACCESS_USER> ClusterCompletableFuture<List<ACCESS_USER>, ClusterConnectionService> getUsersAsync(SseServerProperties.AutoType autoType);
+
+    /* getConnection */
+
+    <ACCESS_USER> ClusterCompletableFuture<List<ConnectionDTO<ACCESS_USER>>, ClusterConnectionService> getConnectionDTOAllAsync(SseServerProperties.AutoType autoType);
 
     /* disconnect */
 

--- a/src/main/java/com/github/sseserver/remote/ConnectionDTO.java
+++ b/src/main/java/com/github/sseserver/remote/ConnectionDTO.java
@@ -1,0 +1,369 @@
+package com.github.sseserver.remote;
+
+import com.github.sseserver.AccessUser;
+import com.github.sseserver.TenantAccessUser;
+import com.github.sseserver.local.SseEmitter;
+import com.github.sseserver.util.AutoTypeBean;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.Map;
+import java.util.Objects;
+
+public class ConnectionDTO<ACCESS_USER> extends AutoTypeBean {
+    // connection
+    private Long id;
+    private Date createTime;
+    private Long timeout;
+    private Date accessTime;
+    private Integer messageCount;
+    private String channel;
+
+    // request
+    private Date lastRequestTime;
+    private Integer requestMessageCount;
+    private Integer requestUploadCount;
+    private Collection<String> listeners;
+    private String locationHref;
+
+    // user
+    private Object accessUserId;
+    private String accessToken;
+    private ACCESS_USER accessUser;
+    private String accessUserClass;
+
+    // client
+    private String clientId;
+    private String clientVersion;
+    private Long clientImportModuleTime;
+    private String clientInstanceId;
+    private Long clientInstanceTime;
+
+    // server
+    private String serverId;
+
+    // http
+    private String requestIp;
+    private String requestDomain;
+    private String userAgent;
+    private Map<String, Object> httpParameters;
+    private Map<String, String> httpHeaders;
+
+    // browser
+    private String screen;
+    private Long totalJSHeapSize;
+    private Long usedJSHeapSize;
+    private Long jsHeapSizeLimit;
+
+    public static <ACCESS_USER> ConnectionDTO<ACCESS_USER> convert(SseEmitter<ACCESS_USER> connection) {
+        ConnectionDTO<ACCESS_USER> dto = new ConnectionDTO<>();
+        dto.setId(connection.getId());
+        dto.setMessageCount(connection.getCount());
+        dto.setTimeout(connection.getTimeout());
+        dto.setChannel(connection.getChannel());
+        dto.setCreateTime(new Date(connection.getCreateTime()));
+        dto.setAccessTime(connection.getAccessTime());
+
+        dto.setLocationHref(connection.getLocationHref());
+        dto.setListeners(connection.getListeners());
+        dto.setRequestMessageCount(connection.getRequestMessageCount());
+        dto.setRequestUploadCount(connection.getRequestUploadCount());
+        long lastRequestTimestamp = connection.getLastRequestTimestamp();
+        if (lastRequestTimestamp > 0) {
+            dto.setLastRequestTime(new Date(lastRequestTimestamp));
+        }
+
+        dto.setAccessToken(connection.getAccessToken());
+        dto.setAccessUserId(connection.getUserId());
+        dto.setAccessUser(connection.getAccessUser());
+        dto.retainClassName(connection.getAccessUser());
+
+        dto.setClientId(connection.getClientId());
+        dto.setClientVersion(connection.getClientVersion());
+        dto.setClientImportModuleTime(connection.getClientImportModuleTime());
+        dto.setClientInstanceId(connection.getClientInstanceId());
+        dto.setClientInstanceTime(connection.getClientInstanceTime());
+
+        dto.setServerId(connection.getServerId());
+
+        dto.setRequestIp(connection.getRequestIp());
+        dto.setRequestDomain(connection.getRequestDomain());
+        dto.setUserAgent(connection.getUserAgent());
+        dto.setHttpHeaders(connection.getHttpHeaders());
+        dto.setHttpParameters(connection.getHttpParameters());
+
+        dto.setScreen(connection.getScreen());
+        dto.setJsHeapSizeLimit(connection.getJsHeapSizeLimit());
+        dto.setTotalJSHeapSize(connection.getTotalJSHeapSize());
+        dto.setUsedJSHeapSize(connection.getUsedJSHeapSize());
+        return dto;
+    }
+
+    public String getServerId() {
+        return serverId;
+    }
+
+    public void setServerId(String serverId) {
+        this.serverId = serverId;
+    }
+
+    public Long getClientImportModuleTime() {
+        return clientImportModuleTime;
+    }
+
+    public void setClientImportModuleTime(Long clientImportModuleTime) {
+        this.clientImportModuleTime = clientImportModuleTime;
+    }
+
+    public String getClientInstanceId() {
+        return clientInstanceId;
+    }
+
+    public void setClientInstanceId(String clientInstanceId) {
+        this.clientInstanceId = clientInstanceId;
+    }
+
+    public Long getClientInstanceTime() {
+        return clientInstanceTime;
+    }
+
+    public void setClientInstanceTime(Long clientInstanceTime) {
+        this.clientInstanceTime = clientInstanceTime;
+    }
+
+    public String getLocationHref() {
+        return locationHref;
+    }
+
+    public void setLocationHref(String locationHref) {
+        this.locationHref = locationHref;
+    }
+
+    public String getScreen() {
+        return screen;
+    }
+
+    public void setScreen(String screen) {
+        this.screen = screen;
+    }
+
+    public Long getTotalJSHeapSize() {
+        return totalJSHeapSize;
+    }
+
+    public void setTotalJSHeapSize(Long totalJSHeapSize) {
+        this.totalJSHeapSize = totalJSHeapSize;
+    }
+
+    public Long getUsedJSHeapSize() {
+        return usedJSHeapSize;
+    }
+
+    public void setUsedJSHeapSize(Long usedJSHeapSize) {
+        this.usedJSHeapSize = usedJSHeapSize;
+    }
+
+    public String getAccessUserClass() {
+        return accessUserClass;
+    }
+
+    public void setAccessUserClass(String accessUserClass) {
+        this.accessUserClass = accessUserClass;
+    }
+
+    public Long getJsHeapSizeLimit() {
+        return jsHeapSizeLimit;
+    }
+
+    public void setJsHeapSizeLimit(Long jsHeapSizeLimit) {
+        this.jsHeapSizeLimit = jsHeapSizeLimit;
+    }
+
+    public String getRequestIp() {
+        return requestIp;
+    }
+
+    public void setRequestIp(String requestIp) {
+        this.requestIp = requestIp;
+    }
+
+    public String getRequestDomain() {
+        return requestDomain;
+    }
+
+    public void setRequestDomain(String requestDomain) {
+        this.requestDomain = requestDomain;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+    }
+
+    public Map<String, Object> getHttpParameters() {
+        return httpParameters;
+    }
+
+    public void setHttpParameters(Map<String, Object> httpParameters) {
+        this.httpParameters = httpParameters;
+    }
+
+    public Map<String, String> getHttpHeaders() {
+        return httpHeaders;
+    }
+
+    public void setHttpHeaders(Map<String, String> httpHeaders) {
+        this.httpHeaders = httpHeaders;
+    }
+
+    public Date getAccessTime() {
+        return accessTime;
+    }
+
+    public void setAccessTime(Date accessTime) {
+        this.accessTime = accessTime;
+    }
+
+    public Date getLastRequestTime() {
+        return lastRequestTime;
+    }
+
+    public void setLastRequestTime(Date lastRequestTime) {
+        this.lastRequestTime = lastRequestTime;
+    }
+
+    public Integer getRequestMessageCount() {
+        return requestMessageCount;
+    }
+
+    public void setRequestMessageCount(Integer requestMessageCount) {
+        this.requestMessageCount = requestMessageCount;
+    }
+
+    public Integer getRequestUploadCount() {
+        return requestUploadCount;
+    }
+
+    public void setRequestUploadCount(Integer requestUploadCount) {
+        this.requestUploadCount = requestUploadCount;
+    }
+
+    public Collection<String> getListeners() {
+        return listeners;
+    }
+
+    public void setListeners(Collection<String> listeners) {
+        this.listeners = listeners;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getClientVersion() {
+        return clientVersion;
+    }
+
+    public void setClientVersion(String clientVersion) {
+        this.clientVersion = clientVersion;
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+
+    public Integer getMessageCount() {
+        return messageCount;
+    }
+
+    public void setMessageCount(Integer messageCount) {
+        this.messageCount = messageCount;
+    }
+
+    public Long getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Long timeout) {
+        this.timeout = timeout;
+    }
+
+    public Date getExpireTime() {
+        if (timeout != null && timeout > 0) {
+            return new Date(createTime.getTime() + timeout);
+        }
+        return null;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getAccessUserName() {
+        if (accessUser instanceof AccessUser) {
+            return ((AccessUser) accessUser).getName();
+        } else if (accessUser instanceof Map) {
+            return Objects.toString(((Map<?, ?>) accessUser).get("name"), null);
+        } else {
+            return null;
+        }
+    }
+
+    public Object getTenantId() {
+        if (accessUser instanceof TenantAccessUser) {
+            return ((TenantAccessUser) accessUser).getTenantId();
+        } else if (accessUser instanceof Map) {
+            return ((Map<?, ?>) accessUser).get("tenantId");
+        } else {
+            return null;
+        }
+    }
+
+    public Object getAccessUserId() {
+        return accessUserId;
+    }
+
+    public void setAccessUserId(Object accessUserId) {
+        this.accessUserId = accessUserId;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public ACCESS_USER getAccessUser() {
+        return accessUser;
+    }
+
+    public void setAccessUser(ACCESS_USER accessUser) {
+        this.accessUser = accessUser;
+    }
+
+}

--- a/src/main/java/com/github/sseserver/remote/RemoteConnectionService.java
+++ b/src/main/java/com/github/sseserver/remote/RemoteConnectionService.java
@@ -2,6 +2,7 @@ package com.github.sseserver.remote;
 
 import com.github.sseserver.ConnectionQueryService;
 import com.github.sseserver.SendService;
+import com.github.sseserver.springboot.SseServerProperties;
 
 import java.io.Closeable;
 import java.io.Serializable;
@@ -24,9 +25,15 @@ public interface RemoteConnectionService extends ConnectionQueryService, SendSer
 
     <ACCESS_USER> RemoteCompletableFuture<List<ACCESS_USER>, RemoteConnectionService> getUsersAsync();
 
+    <ACCESS_USER> RemoteCompletableFuture<List<ACCESS_USER>, RemoteConnectionService> getUsersAsync(SseServerProperties.AutoType autoType);
+
     <ACCESS_USER> RemoteCompletableFuture<List<ACCESS_USER>, RemoteConnectionService> getUsersByListeningAsync(String sseListenerName);
 
     <ACCESS_USER> RemoteCompletableFuture<List<ACCESS_USER>, RemoteConnectionService> getUsersByTenantIdListeningAsync(Serializable tenantId, String sseListenerName);
+
+    /* getConnection */
+
+    <ACCESS_USER> RemoteCompletableFuture<List<ConnectionDTO<ACCESS_USER>>, RemoteConnectionService> getConnectionDTOAllAsync(SseServerProperties.AutoType autoTypeEnum);
 
     /* getUserIds */
 

--- a/src/main/java/com/github/sseserver/remote/RemoteResponseMessage.java
+++ b/src/main/java/com/github/sseserver/remote/RemoteResponseMessage.java
@@ -132,4 +132,20 @@ public class RemoteResponseMessage implements Message {
     public void setChannelList(Collection<String> channelList) {
         this.channelList = channelList;
     }
+
+    @Override
+    public String toString() {
+        return "RemoteResponseMessage{" +
+                "id='" + id + '\'' +
+                ", remoteMessageRepositoryId='" + remoteMessageRepositoryId + '\'' +
+                ", eventName='" + eventName + '\'' +
+                ", body=" + body +
+                ", filters=" + filters +
+                ", listenerName='" + listenerName + '\'' +
+                ", tenantIdList=" + tenantIdList +
+                ", userIdList=" + userIdList +
+                ", accessTokenList=" + accessTokenList +
+                ", channelList=" + channelList +
+                '}';
+    }
 }

--- a/src/main/java/com/github/sseserver/remote/ServiceDiscoveryService.java
+++ b/src/main/java/com/github/sseserver/remote/ServiceDiscoveryService.java
@@ -18,7 +18,7 @@ public interface ServiceDiscoveryService {
                     nacos.getServiceName(),
                     nacos.getClusterName(),
                     nacos.buildProperties(),
-                    remote.getAutoType());
+                    remote);
         } else {
             throw new IllegalArgumentException("ServiceDiscoveryService newInstance fail! remote discovery url is empty!");
         }

--- a/src/main/java/com/github/sseserver/springboot/SseServerAutoConfiguration.java
+++ b/src/main/java/com/github/sseserver/springboot/SseServerAutoConfiguration.java
@@ -1,5 +1,9 @@
 package com.github.sseserver.springboot;
 
+import com.github.sseserver.local.LocalController;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +28,23 @@ public class SseServerAutoConfiguration {
         SseServerProperties properties = new SseServerProperties();
         bindNacos(properties.getRemote().getNacos(), environment);
         return properties;
+    }
+
+    @Bean
+    public CommandLineRunner sseCommandLineRunner() {
+        return new CommandLineRunner() {
+            @Autowired
+            private ListableBeanFactory beanFactory;
+
+            @Override
+            public void run(String... args) {
+                String[] names = beanFactory.getBeanNamesForType(LocalController.class, false, true);
+                for (String name : names) {
+                    LocalController bean = beanFactory.getBean(name, LocalController.class);
+                    bean.registerInstance();
+                }
+            }
+        };
     }
 
     public void bindNacos(SseServerProperties.Remote.Nacos nacos, Environment environment) {

--- a/src/main/java/com/github/sseserver/springboot/SseServerProperties.java
+++ b/src/main/java/com/github/sseserver/springboot/SseServerProperties.java
@@ -22,6 +22,12 @@ public class SseServerProperties {
         return remote;
     }
 
+    public enum AutoType {
+        DISABLED,
+        CLASS_NOT_FOUND_USE_MAP,
+        CLASS_NOT_FOUND_THROWS,
+    }
+
     public static class Local {
 
     }
@@ -30,16 +36,11 @@ public class SseServerProperties {
 
     }
 
-    public enum AutoType {
-        DISABLED,
-        CLASS_NOT_FOUND_USE_MAP,
-        CLASS_NOT_FOUND_THROWS,
-    }
-
     public static class Remote {
-        private final Nacos nacos = new Nacos();
         private boolean enabled = false;
-        private AutoType autoType = AutoType.CLASS_NOT_FOUND_THROWS;
+        private final Nacos nacos = new Nacos();
+        private final MessageRepository messageRepository = new MessageRepository();
+        private final ConnectionService connectionService = new ConnectionService();
 
         public boolean isEnabled() {
             return enabled;
@@ -49,16 +50,40 @@ public class SseServerProperties {
             this.enabled = enabled;
         }
 
-        public AutoType getAutoType() {
-            return autoType;
+        public MessageRepository getMessageRepository() {
+            return messageRepository;
         }
 
-        public void setAutoType(AutoType autoType) {
-            this.autoType = autoType;
+        public ConnectionService getConnectionService() {
+            return connectionService;
         }
 
         public Nacos getNacos() {
             return nacos;
+        }
+
+        public static class MessageRepository {
+            private AutoType autoType = AutoType.CLASS_NOT_FOUND_USE_MAP;
+
+            public AutoType getAutoType() {
+                return autoType;
+            }
+
+            public void setAutoType(AutoType autoType) {
+                this.autoType = autoType;
+            }
+        }
+
+        public static class ConnectionService {
+            private AutoType autoType = AutoType.CLASS_NOT_FOUND_THROWS;
+
+            public AutoType getAutoType() {
+                return autoType;
+            }
+
+            public void setAutoType(AutoType autoType) {
+                this.autoType = autoType;
+            }
         }
 
         public static class Nacos {

--- a/src/main/java/com/github/sseserver/util/AutoTypeBean.java
+++ b/src/main/java/com/github/sseserver/util/AutoTypeBean.java
@@ -1,0 +1,127 @@
+package com.github.sseserver.util;
+
+import com.github.sseserver.springboot.SseServerProperties;
+
+import java.util.*;
+
+public class AutoTypeBean {
+    private Map<String, Collection<Integer>> arrayClassName;
+    private String objectClassName;
+
+    /**
+     * 保留类型
+     *
+     * @param data
+     */
+    public void retainClassName(Object data) {
+        if (data instanceof Collection) {
+            int i = 0;
+            Map<String, Collection<Integer>> classMap = new HashMap<>(1);
+            for (Object item : (Collection) data) {
+                if (!TypeUtil.isBasicType(item)) {
+                    classMap.computeIfAbsent(item.getClass().getName(), e -> new ArrayList<>())
+                            .add(i);
+                }
+                i++;
+            }
+            arrayClassName = classMap;
+        } else if (TypeUtil.isBasicType(data)) {
+
+        } else {
+            objectClassName = data.getClass().getName();
+        }
+    }
+
+    /**
+     * 转换类型
+     *
+     * @param data
+     * @param arrayClassName
+     * @param objectClassName
+     * @param autoTypeEnum
+     * @param classNotFoundCacheSet
+     * @param <T>
+     * @return
+     * @throws ClassNotFoundException
+     */
+    public static <T> T cast(Object data,
+                             Map<String, Collection<Integer>> arrayClassName,
+                             String objectClassName,
+                             SseServerProperties.AutoType autoTypeEnum, Set<String> classNotFoundCacheSet) throws ClassNotFoundException {
+        if (autoTypeEnum == SseServerProperties.AutoType.DISABLED) {
+            return (T) data;
+        }
+
+        if (objectClassName != null) {
+            if (autoTypeEnum == SseServerProperties.AutoType.CLASS_NOT_FOUND_USE_MAP
+                    && classNotFoundCacheSet.contains(objectClassName)) {
+                return (T) data;
+            } else {
+                try {
+                    return TypeUtil.castBean(data, objectClassName);
+                } catch (ClassNotFoundException e) {
+                    classNotFoundCacheSet.add(objectClassName);
+                    if (autoTypeEnum == SseServerProperties.AutoType.CLASS_NOT_FOUND_THROWS) {
+                        throw e;
+                    } else {
+                        return (T) data;
+                    }
+                }
+            }
+        } else if (arrayClassName != null && data instanceof Collection) {
+            for (Map.Entry<String, Collection<Integer>> entry : arrayClassName.entrySet()) {
+                Collection<Integer> value = entry.getValue();
+                if (!(value instanceof Set)) {
+                    entry.setValue(new HashSet<>(value));
+                }
+            }
+            List list = new ArrayList(((Collection<?>) data).size());
+            int i = 0;
+            for (Object item : (Collection) data) {
+                for (Map.Entry<String, Collection<Integer>> entry : arrayClassName.entrySet()) {
+                    if (entry.getValue().contains(i)) {
+                        objectClassName = entry.getKey();
+                        break;
+                    }
+                }
+                if (objectClassName == null) {
+                    list.add(item);
+                } else if (autoTypeEnum == SseServerProperties.AutoType.CLASS_NOT_FOUND_USE_MAP
+                        && classNotFoundCacheSet.contains(objectClassName)) {
+                    list.add(item);
+                } else {
+                    try {
+                        list.add(TypeUtil.castBean(item, objectClassName));
+                    } catch (ClassNotFoundException e) {
+                        classNotFoundCacheSet.add(objectClassName);
+                        if (autoTypeEnum == SseServerProperties.AutoType.CLASS_NOT_FOUND_USE_MAP) {
+                            list.add(item);
+                        } else {
+                            throw e;
+                        }
+                    }
+                }
+                i++;
+            }
+            return (T) list;
+        } else {
+            return (T) data;
+        }
+    }
+
+    public void setArrayClassName(Map<String, Collection<Integer>> arrayClassName) {
+        this.arrayClassName = arrayClassName;
+    }
+
+    public void setObjectClassName(String objectClassName) {
+        this.objectClassName = objectClassName;
+    }
+
+    public Map<String, Collection<Integer>> getArrayClassName() {
+        return arrayClassName;
+    }
+
+    public String getObjectClassName() {
+        return objectClassName;
+    }
+}

--- a/src/main/java/com/github/sseserver/util/LambdaUtil.java
+++ b/src/main/java/com/github/sseserver/util/LambdaUtil.java
@@ -34,7 +34,7 @@ public class LambdaUtil {
         return (o1, o2) -> o1 != null ? o1 : o2;
     }
 
-    public static <T extends Collection> BiFunction<T, T, T> reduceList() {
+    public static <T extends Collection<E>, E> BiFunction<T, T, T> reduceList() {
         return (o1, o2) -> {
             o1.addAll(o2);
             return o1;

--- a/src/main/java/com/github/sseserver/util/PageInfo.java
+++ b/src/main/java/com/github/sseserver/util/PageInfo.java
@@ -13,6 +13,7 @@ public class PageInfo<T> implements Serializable, Iterable<T> {
     private int pageNum;
     private int pageSize;
     private List<T> list;
+    private boolean timeout;
 
     public PageInfo() {
         this(new ArrayList<>());
@@ -20,11 +21,17 @@ public class PageInfo<T> implements Serializable, Iterable<T> {
 
     public PageInfo(List<T> list) {
         this.list = Objects.requireNonNull(list);
-        this.total = (long) list.size();
+        this.total = list.size();
     }
 
     public static <T> PageInfo<T> empty() {
         return PageInfo.of(Collections.emptyList());
+    }
+
+    public static <T> PageInfo<T> timeout() {
+        PageInfo<T> info = PageInfo.of(Collections.emptyList());
+        info.setTimeout(true);
+        return info;
     }
 
     public static <T> PageInfo<T> of(List<T> list, int pageNum, int pageSize) {
@@ -125,6 +132,14 @@ public class PageInfo<T> implements Serializable, Iterable<T> {
 
     public void setList(List<T> list) {
         this.list = list;
+    }
+
+    public boolean isTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(boolean timeout) {
+        this.timeout = timeout;
     }
 
     @Override

--- a/src/main/java/com/github/sseserver/util/TypeUtil.java
+++ b/src/main/java/com/github/sseserver/util/TypeUtil.java
@@ -52,7 +52,7 @@ public class TypeUtil {
         }
     }
 
-    public static <T> T castBean(Object obj, String typeString) throws ClassNotFoundException{
+    public static <T> T castBean(Object obj, String typeString) throws ClassNotFoundException {
         if (obj == null || typeString == null) {
             return (T) obj;
         }

--- a/src/main/resources/sse.js
+++ b/src/main/resources/sse.js
@@ -9,11 +9,11 @@
  *   <dependency>
  *      <groupId>com.github.wangzihaogithub</groupId>
  *      <artifactId>sse-server</artifactId>
- *      <version>1.2.0</version>
+ *      <version>1.2.1</version>
  *   </dependency>
  */
 class Sse {
-  static version = '1.2.0'
+  static version = '1.2.1'
   static DEFAULT_OPTIONS = {
     url: '/api/sse',
     keepaliveTime: 900000,


### PR DESCRIPTION
1. http接口支持集群全局查询[用户信息,链接信息，Qos的消息挤压信息]
2. 在任何一个节点中，获取的数据都是原始的Class类型,不会变成Map。使用者可以配置NotFoundClass时，抛出异常还是用Map兼容#SseServerProperties#AutoType
3. 4.Qos的MessagID字符串会拼接上消息生产者的服务器IP，方便排查问题